### PR TITLE
setup: configure upload_docs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[upload_sphinx]
+upload-dir = docs/api_reference/_build/html


### PR DESCRIPTION
Tell setuptools where we build the documentation so that
"python setup.py upload_docs" works.
