### PR TITLE
sched: Update usage of EventPlot API

### DIFF
--- a/bart/sched/SchedAssert.py
+++ b/bart/sched/SchedAssert.py
@@ -633,4 +633,6 @@ class SchedAssert(object):
         names = [self.name]
         num_lanes = self._topology.level_span(level)
         lane_prefix = level.upper() + ": "
-        return trappy.EventPlot(events, names, lane_prefix, num_lanes, xlim)
+        return trappy.EventPlot(events, names, xlim,
+                                lane_prefix=lane_prefix,
+                                num_lanes=num_lanes)

--- a/bart/sched/SchedMultiAssert.py
+++ b/bart/sched/SchedMultiAssert.py
@@ -248,4 +248,6 @@ class SchedMultiAssert(object):
         names = [s.name for s in self._asserts.values()]
         num_lanes = self._topology.level_span(level)
         lane_prefix = level.upper() + ": "
-        return trappy.EventPlot(events, names, lane_prefix, num_lanes, xlim)
+        return trappy.EventPlot(events, names, xlim,
+                                lane_prefix=lane_prefix,
+                                num_lanes=num_lanes)


### PR DESCRIPTION
The EventPlot API has changed and accepts keyword args
for num_lanes and lane_prefix.

Signed-off-by: Kapileshwar Singh kapileshwar.singh@arm.com
