### PR TITLE
setup: Depend on trappy >= 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ to assert behaviours using the FTrace output from the kernel
 """
 
 REQUIRES = [
-    "TRAPpy",
+    "TRAPpy>=2.0",
 ]
 
 setup(name='bart-py',


### PR DESCRIPTION
trappy has changed the API for EventPlot in f4eefc02239a ("plotter:
EventPlot: Allow specification of lane names") which will be released
in trappy 2.0.  This is fixed in 5b1275f59fec ("sched: Update usage of
EventPlot API") in bart.  Make sure bart the next version of bart
depends on the appropriate version of trappy.
