### PR TITLE
sched: Use Median for calculation of the period of a task

### DIFF
--- a/bart/sched/SchedAssert.py
+++ b/bart/sched/SchedAssert.py
@@ -445,7 +445,19 @@ class SchedAssert(object):
         return operator(run_time, expected_value)
 
     def getPeriod(self, window=None, align="start"):
-        """Return average period of the task in (ms)
+        """Return the period of the task in (ms)
+
+        Let's say a task started execution at the following times:
+
+            .. math::
+
+                T_1, T_2, ...T_n
+
+        The period is defined as:
+
+            .. math::
+
+                Median((T_2 - T_1), (T_4 - T_3), ....(T_n - T_{n-1}))
 
         :param window: A (start, end) tuple to limit the scope of the
             residency calculation.
@@ -460,12 +472,12 @@ class SchedAssert(object):
         """
 
         agg = self._aggregator(sconf.period)
-        period = agg.aggregate(level="all", window=window)[0]
-        total, length = map(sum, zip(*period))
-        if length == 0:
+        deltas = agg.aggregate(level="all", window=window)[0]
+
+        if not len(deltas):
             return float("NaN")
         else:
-            return (total * 1000) / length
+            return np.median(deltas) * 1000
 
     def assertPeriod(
             self,


### PR DESCRIPTION
Here is what I do for calculating the period of the task:

Let's say a task started execution at the following times

```
                   T_1, T_2, ...T_n
```

Currently for align = "start" the period is

Average of:

```
            (T_2 - T_1), (T_4 - T_3), ....(T_n - T_{n-1})
```

In this method we have an edge condition when a task does not run
for a particular time or when it migrates between CPUs causing the
average to end up significantly higher than the actual period of
the task. However, as periodicity is statistical in nature
and can vary during the lifetime of the task, we can have a
good understanding of the periodicity by getting the median period
of the deltas above.

Should be merged with ARM-software/trappy#61
Fixes #26
Signed-off-by: Kapileshwar Singh kapileshwar.singh@arm.com
