### PR TITLE
gitignore: ignore files generated by setuptools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.pyc
 .ipynb_checkpoints
 example_trace_dat*
+/dist/
+/build/
+/bart_py.egg-info/


### PR DESCRIPTION
"python setup.py sdist" and friends generate all these folders.  Ignore
them.
