### PR TITLE
bart: grow your own listify

### DIFF
--- a/bart/common/Utils.py
+++ b/bart/common/Utils.py
@@ -21,6 +21,16 @@ import numpy as np
 # pylint fails to recognize numpy members.
 # pylint: disable=no-member
 
+def listify(to_select):
+    """Utitlity function to handle both single and
+    list inputs
+    """
+
+    if not isinstance(to_select, list):
+        to_select = [to_select]
+
+    return to_select
+
 def init_run(trace):
     """Initialize the Run Object
 

--- a/bart/sched/SchedAssert.py
+++ b/bart/sched/SchedAssert.py
@@ -22,7 +22,6 @@ to aggregate statistics over processor hierarchies.
 import trappy
 import itertools
 import math
-from trappy.plotter.Utils import listify
 from trappy.stats.Aggregator import MultiTriggerAggregator
 from trappy.stats import SchedConf as sconf
 from bart.common import Utils
@@ -609,7 +608,7 @@ class SchedAssert(object):
         """
 
         first_cpu = self.getFirstCpu(window=window)
-        cpus = listify(cpus)
+        cpus = Utils.listify(cpus)
         return first_cpu in cpus
 
     def generate_events(self, level, start_id=0, window=None):

--- a/bart/sched/SchedMatrix.py
+++ b/bart/sched/SchedMatrix.py
@@ -70,7 +70,6 @@ import trappy
 import numpy as np
 from trappy.stats.Aggregator import MultiTriggerAggregator
 from trappy.stats.Correlator import Correlator
-from trappy.plotter.Utils import listify
 from trappy.stats import SchedConf as sconf
 from bart.common import Utils
 
@@ -156,7 +155,7 @@ class SchedMatrix(object):
         run = Utils.init_run(trace)
         reference_run = Utils.init_run(reference_trace)
 
-        self._execnames = listify(execnames)
+        self._execnames = Utils.listify(execnames)
         self._reference_pids = self._populate_pids(reference_run)
         self._pids = self._populate_pids(run)
         self._dimension = len(self._pids)

--- a/bart/sched/SchedMultiAssert.py
+++ b/bart/sched/SchedMultiAssert.py
@@ -20,7 +20,6 @@ import re
 import inspect
 import trappy
 from trappy.stats import SchedConf as sconf
-from trappy.plotter.Utils import listify
 from bart.sched.SchedAssert import SchedAssert
 from bart.common import Utils
 
@@ -144,7 +143,7 @@ class SchedMultiAssert(object):
         if execnames and pids:
             raise ValueError('Either pids or execnames must be specified')
         if execnames:
-            self._execnames = listify(execnames)
+            self._execnames = Utils.listify(execnames)
             self._pids = self._populate_pids()
         elif pids:
             self._pids = pids


### PR DESCRIPTION
bart imports listify from trappy.plotter.utils.  trappy.plotter requires
matplotlib, which makes bart require matplotlib.  For listify.  Get your
own version of listify to avoid the cross-import.
