### PR TITLE
sched: SchedAssert: fix documentation for getResidency()

### DIFF
--- a/bart/sched/SchedAssert.py
+++ b/bart/sched/SchedAssert.py
@@ -134,14 +134,16 @@ class SchedAssert(object):
         a particular group of a topological level. For example:
         ::
 
-            clusters=[]
-            big = [1,2]
-            little = [0,3,4,5]
+            from trappy.stats.Topology import Topology
+
+            clusters = []
+            big = [1, 2]
+            little = [0, 3, 4, 5]
 
             topology = Topology(clusters=clusters)
 
-            level="cluster"
-            node = [1,2]
+            s = SchedAssert(trace, topology, pid=123)
+            s.getResidency("cluster", big)
 
         This will return the residency of the task on the big cluster. If
         percent is specified it will be normalized to the total runtime


### PR DESCRIPTION
The example of the getResidency() function is incomplete.  Fix the
example so that it matches the documentation.
