### PR TITLE
README: explicitly state that the instructions are for Ubuntu 14.04 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Verifying behaviours when different components/patches are integrated.
 
 # Installation
 
+The following instructions are for Ubuntu 14.04 LTS but they should
+also work with Debian jessie.  Older versions of Ubuntu or Debian
+(e.g. Ubuntu 12.04 or Debian wheezy) will likely require to install
+more packages from pip as the ones present in Ubuntu 12.04 or Debian
+wheezy will probably be too old.
+
 ## Required dependencies
 
 #### Install additional tools required for some tests and functionalities


### PR DESCRIPTION
We have always implicitly supported Ubuntu 14.04 LTS as the minimum version.
State it explicitly in the README.
