### PR TITLE
get_pids_for_process() fixes

### DIFF
--- a/bart/sched/functions.py
+++ b/bart/sched/functions.py
@@ -436,6 +436,9 @@ def get_pids_for_process(ftrace, execname, cls=None):
             df = ftrace.sched_switch.data_frame
         except AttributeError:
             raise ValueError("SchedSwitch event not found in ftrace")
+
+        if len(df) == 0:
+            raise ValueError("SchedSwitch event not found in ftrace")
     else:
         event = getattr(ftrace, cls.name)
         df = event.data_frame

--- a/bart/sched/functions.py
+++ b/bart/sched/functions.py
@@ -443,7 +443,7 @@ def get_pids_for_process(ftrace, execname, cls=None):
         event = getattr(ftrace, cls.name)
         df = event.data_frame
 
-    mask = df["next_comm"].apply(lambda x : True if x.startswith(execname) else False)
+    mask = df["next_comm"].apply(lambda x : True if x == execname else False)
     return list(np.unique(df[mask]["next_pid"].values))
 
 def get_task_name(ftrace, pid, cls=None):

--- a/tests/test_sched_functions.py
+++ b/tests/test_sched_functions.py
@@ -37,3 +37,33 @@ class TestSchedFunctions(utils_tests.SetupDirectory):
         trace = trappy.FTrace(trace_file)
         with self.assertRaises(ValueError):
             get_pids_for_process(trace, "foo")
+
+    def test_get_pids_for_process_funny_process_names(self):
+        """get_pids_for_process() works when a process name is a substring of another"""
+        from bart.sched.functions import get_pids_for_process
+
+        trace_file = "trace.txt"
+        raw_trace_file = "trace.raw.txt"
+        in_data = """          <idle>-0     [001] 10826.894644: sched_switch:          prev_comm=swapper/1 prev_pid=0 prev_prio=120 prev_state=0 next_comm=rt-app next_pid=3268 next_prio=120
+            wmig-3268  [001] 10826.894778: sched_switch:          prev_comm=wmig prev_pid=3268 prev_prio=120 prev_state=1 next_comm=rt-app next_pid=3269 next_prio=120
+           wmig1-3269  [001] 10826.905152: sched_switch:          prev_comm=wmig1 prev_pid=3269 prev_prio=120 prev_state=1 next_comm=wmig next_pid=3268 next_prio=120
+            wmig-3268  [001] 10826.915384: sched_switch:          prev_comm=wmig prev_pid=3268 prev_prio=120 prev_state=1 next_comm=swapper/1 next_pid=0 next_prio=120
+          <idle>-0     [005] 10826.995169: sched_switch:          prev_comm=swapper/5 prev_pid=0 prev_prio=120 prev_state=0 next_comm=wmig1 next_pid=3269 next_prio=120
+           wmig1-3269  [005] 10827.007064: sched_switch:          prev_comm=wmig1 prev_pid=3269 prev_prio=120 prev_state=0 next_comm=wmig next_pid=3268 next_prio=120
+            wmig-3268  [005] 10827.019061: sched_switch:          prev_comm=wmig prev_pid=3268 prev_prio=120 prev_state=0 next_comm=wmig1 next_pid=3269 next_prio=120
+           wmig1-3269  [005] 10827.031061: sched_switch:          prev_comm=wmig1 prev_pid=3269 prev_prio=120 prev_state=0 next_comm=wmig next_pid=3268 next_prio=120
+            wmig-3268  [005] 10827.050645: sched_switch:          prev_comm=wmig prev_pid=3268 prev_prio=120 prev_state=1 next_comm=swapper/5 next_pid=0 next_prio=120
+"""
+
+        # We create an empty trace.txt to please trappy ...
+        with open(trace_file, "w") as fout:
+            fout.write("")
+
+        # ... but we only put the sched_switch events in the raw trace
+        # file because that's where trappy is going to look for
+        with open(raw_trace_file, "w") as fout:
+            fout.write(in_data)
+
+        trace = trappy.FTrace(trace_file)
+
+        self.assertEquals(get_pids_for_process(trace, "wmig"), [3268])

--- a/tests/test_sched_functions.py
+++ b/tests/test_sched_functions.py
@@ -1,0 +1,39 @@
+#    Copyright 2016-2016 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import trappy
+
+import utils_tests
+
+class TestSchedFunctions(utils_tests.SetupDirectory):
+    def __init__(self, *args, **kwargs):
+        super(TestSchedFunctions, self).__init__([], *args, **kwargs)
+
+    def test_get_pids_for_processes_no_sched_switch(self):
+        """get_pids_for_processes() raises an exception if the trace doesn't have a sched_switch event"""
+        from bart.sched.functions import get_pids_for_process
+
+        trace_file = "trace.txt"
+        raw_trace_file = "trace.raw.txt"
+
+        with open(trace_file, "w") as fout:
+            fout.write("")
+
+        with open(raw_trace_file, "w") as fout:
+            fout.write("")
+
+        trace = trappy.FTrace(trace_file)
+        with self.assertRaises(ValueError):
+            get_pids_for_process(trace, "foo")


### PR DESCRIPTION
Lisa's HMP parity testsuite fails for the Wake Migration.  The test spawns two process `wmig` and `wmig1`.  Having a process name that is a substring of another confuses bart:

```
======================================================================
ERROR: test suite for <class 'hmp_parity.WakeMigration'>
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/nose/suite.py", line 208, in run
    self.setUp()
  File "/usr/lib/python2.7/dist-packages/nose/suite.py", line 291, in setUp
    self.setupContext(ancestor)
  File "/usr/lib/python2.7/dist-packages/nose/suite.py", line 314, in setupContext
    try_run(context, names)
  File "/usr/lib/python2.7/dist-packages/nose/util.py", line 471, in try_run
    return func()
  File "/vagrant/tests/eas/hmp_parity.py", line 465, in setUpClass
    cls.offset = cls.get_offset(cls.tasks[0])
  File "/vagrant/tests/eas/hmp_parity.py", line 496, in get_offset
    execname=task_name).getStartTime()
  File "/home/vagrant/lisa/libs/bart/bart/sched/SchedAssert.py", line 77, in __init__
    self._pid = self._validate_pid(pid)
  File "/home/vagrant/lisa/libs/bart/bart/sched/SchedAssert.py", line 95, in _validate_pid
    self.execname))
RuntimeError: There should be exactly one PID [3268, 3269] for wmig
```
