### PR TITLE
sched: SchedMultiAssert: add getCPUBusyTime

### DIFF
--- a/bart/sched/SchedAssert.py
+++ b/bart/sched/SchedAssert.py
@@ -149,7 +149,7 @@ class SchedAssert(object):
         of the task
 
         :param level: The topological level to which the group belongs
-        :type level (hashable):
+        :type level: str
 
         :param node: The group of CPUs for which residency
             needs to calculated
@@ -195,7 +195,7 @@ class SchedAssert(object):
             percent=False):
         """
         :param level: The topological level to which the group belongs
-        :type level (hashable):
+        :type level: str
 
         :param node: The group of CPUs for which residency
             needs to calculated
@@ -324,7 +324,7 @@ class SchedAssert(object):
            :code:`from_node` to the :code:`to_node`:
 
         :param level: The topological level to which the group belongs
-        :type level (hashable):
+        :type level: str
 
         :param from_node: The node from which the task switches out
         :type from_node: list

--- a/bart/sched/SchedMultiAssert.py
+++ b/bart/sched/SchedMultiAssert.py
@@ -227,6 +227,44 @@ class SchedMultiAssert(object):
         else:
             return result
 
+    def getCPUBusyTime(self, level, node, window=None, percent=False):
+        """Get the amount of time the cpus in the system were busy executing the
+        tasks
+
+        :param level: The topological level to which the group belongs
+        :type level: string
+
+        :param node: The group of CPUs for which to calculate busy time
+        :type node: list
+
+        :param window: A (start, end) tuple to limit the scope of the
+        calculation.
+        :type window: tuple
+
+        :param percent: If True the result is normalized to the total
+        time of the period, either the window or the full lenght of
+        the trace.
+        :type percent: bool
+
+        .. math::
+
+            R = \\frac{T_{busy} \\times 100}{T_{total}}
+
+        """
+        residencies = self.getResidency(level, node, window=window)
+
+        busy_time = sum(v["residency"] for v in residencies.itervalues())
+
+        if percent:
+            if window:
+                total_time = window[1] - window[0]
+            else:
+                total_time = self._ftrace.get_duration()
+            num_cpus = len(node)
+            return busy_time / (total_time * num_cpus) * 100
+        else:
+            return busy_time
+
     def generate_events(self, level, window=None):
         """Generate Events for the trace plot
 

--- a/tests/test_sched_assert.py
+++ b/tests/test_sched_assert.py
@@ -14,13 +14,14 @@
 #
 
 
+from bart.sched.SchedAssert import SchedAssert
+from bart.sched.SchedMultiAssert import SchedMultiAssert
 import trappy
 from trappy.stats.Topology import Topology
 import unittest
 
 import utils_tests
 
-from bart.sched.SchedAssert import SchedAssert
 
 @unittest.skipUnless(utils_tests.trace_cmd_installed(),
                      "trace-cmd not installed")
@@ -68,3 +69,41 @@ class TestSchedAssert(utils_tests.SetupDirectory):
         expected_time = 0.000817
         self.assertAlmostEqual(s.getRuntime(window=window), expected_time,
                                places=9)
+
+class TestSchedMultiAssert(utils_tests.SetupDirectory):
+    def __init__(self, *args, **kwargs):
+        self.big = [1,2]
+        self.little = [0, 3, 4, 5]
+        self.clusters = [self.big, self.little]
+        self.all_cpus = sorted(self.big + self.little)
+        self.topology = Topology(clusters=self.clusters)
+        super(TestSchedMultiAssert, self).__init__(
+             [("raw_trace.dat", "trace.dat")],
+             *args,
+             **kwargs)
+
+    def test_cpu_busy_time(self):
+        """SchedMultiAssert.getCPUBusyTime() work"""
+
+        # precalculated values against these processes in the trace
+        pids = [4729, 4734]
+        first_time = .000214
+        last_time = .003171
+
+        tr = trappy.FTrace()
+        sma = SchedMultiAssert(tr, self.topology, pids=pids)
+
+        expected_busy_time = 0.0041839999754810708
+        busy_time = sma.getCPUBusyTime("all", self.all_cpus, window=(first_time, last_time))
+        self.assertAlmostEqual(busy_time, expected_busy_time)
+
+        # percent calculation
+        expected_busy_pct = 23.582459561949445
+        busy_pct= sma.getCPUBusyTime("all", self.all_cpus, percent=True,
+                                     window=(first_time, last_time))
+        self.assertAlmostEqual(busy_pct, expected_busy_pct)
+
+        # percent without a window
+        expected_busy_pct = 23.018818156540004
+        busy_pct= sma.getCPUBusyTime("cluster", self.little, percent=True)
+        self.assertAlmostEqual(busy_pct, expected_busy_pct)


### PR DESCRIPTION
For multiple tasks, it's valuable to verify that they have ran on a set of cpus for a given time.  With `SchedMultiAssert.getCPUBusyTime()` we can do that now.
