### PR TITLE
common: Fix doc for area_under_curve `sign` param

### DIFF
--- a/bart/common/Utils.py
+++ b/bart/common/Utils.py
@@ -77,7 +77,7 @@ def area_under_curve(series, sign=None, method="trapz", step="post"):
         or negative regions. Can have two values
 
         - `"+"`
-        - `"-"`
+        - `"="`
     :type sign: str
 
     :param method: The method for area calculation. This can


### PR DESCRIPTION
Relevant code [here](https://github.com/bjackman/bart/blob/56876aa79b4dcaf3f29c60642f0c8b2858c61376/bart/common/Utils.py#L146)
