### PR TITLE
travis-ci: Install Cython before Pandas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
   - sudo dpkg -i trace-cmd_2.4.0-1_amd64.deb
 install:
   - pip install matplotlib
+  - pip install Cython --install-option="--no-cython-compile"
   - pip install pandas
   - pip install ipython[all]
   - pip install --upgrade trappy


### PR DESCRIPTION
Pandas 0.19 requires Cython but it is not automatically installed by
Pip. So do it manually.
