### PR TITLE
Python 3 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
-  - "2.7"
+  - "2.7.12"
+  - "3.4.8"
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libfreetype6-dev
@@ -8,15 +9,12 @@ before_install:
   - wget http://ftp.us.debian.org/debian/pool/main/t/trace-cmd/trace-cmd_2.4.0-1_amd64.deb
   - sudo dpkg -i trace-cmd_2.4.0-1_amd64.deb
 install:
-  - pip install matplotlib
   - pip install Cython --install-option="--no-cython-compile"
-  - pip install pandas
-  - pip install hypothesis
-  - pip install ipython[all]
-  - pip install --upgrade trappy
+  # IPython 6.0.0 requires Python 3.3. Use an older version so we can keep using
+  # Python 2.7
+  - pip install "ipython[all]<6.0.0"
+  - python ./setup.py install
 script: nosetests
-virtualenv:
-  system_site_packages: true
 notifications:
   email:
     recipients:

--- a/bart/__init__.py
+++ b/bart/__init__.py
@@ -15,6 +15,8 @@
 
 """Initialization for bart"""
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 import bart.sched
 import bart.common

--- a/bart/__init__.py
+++ b/bart/__init__.py
@@ -14,6 +14,7 @@
 #
 
 """Initialization for bart"""
+from __future__ import unicode_literals
 
 import bart.sched
 import bart.common

--- a/bart/common/Analyzer.py
+++ b/bart/common/Analyzer.py
@@ -18,7 +18,9 @@ based on the grammar defined in trappy.stats.grammar. The class is
 also intended to have aggregator based functionality. This is not
 implemented yet.
 """
+from __future__ import unicode_literals
 
+from builtins import object
 from trappy.stats.grammar import Parser
 import warnings
 import numpy as np

--- a/bart/common/Analyzer.py
+++ b/bart/common/Analyzer.py
@@ -19,6 +19,8 @@ also intended to have aggregator based functionality. This is not
 implemented yet.
 """
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from builtins import object
 from trappy.stats.grammar import Parser

--- a/bart/common/Utils.py
+++ b/bart/common/Utils.py
@@ -15,6 +15,8 @@
 
 """Utility functions for sheye"""
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from past.builtins import basestring
 import trappy

--- a/bart/common/Utils.py
+++ b/bart/common/Utils.py
@@ -14,7 +14,9 @@
 #
 
 """Utility functions for sheye"""
+from __future__ import unicode_literals
 
+from past.builtins import basestring
 import trappy
 import numpy as np
 

--- a/bart/common/__init__.py
+++ b/bart/common/__init__.py
@@ -15,7 +15,8 @@
 
 """Initialization for bart.common"""
 from __future__ import unicode_literals
-
+from __future__ import division
+from __future__ import print_function
 
 from bart.common import Utils
 from bart.common import Analyzer

--- a/bart/common/__init__.py
+++ b/bart/common/__init__.py
@@ -14,6 +14,7 @@
 #
 
 """Initialization for bart.common"""
+from __future__ import unicode_literals
 
 
 from bart.common import Utils

--- a/bart/common/signal.py
+++ b/bart/common/signal.py
@@ -47,9 +47,9 @@
 """
 from __future__ import division
 from __future__ import unicode_literals
+from __future__ import print_function
 
 from builtins import object
-from past.utils import old_div
 from trappy.stats.grammar import Parser
 from trappy.stats import StatConf
 from bart.common.Utils import area_under_curve, interval_sum
@@ -246,7 +246,7 @@ class SignalCompare(object):
             duration = min(a_piv.last_valid_index(), b_piv.last_valid_index())
             duration -= max(a_piv.first_valid_index(),
                             b_piv.first_valid_index())
-            duration = old_div(interval_sum(mask[pivot_val], step=step), duration)
+            duration = interval_sum(mask[pivot_val], step=step) / duration
 
             if self._pivot:
                 result[self._pivot][pivot_val] = area, duration

--- a/bart/common/signal.py
+++ b/bart/common/signal.py
@@ -45,7 +45,11 @@
         - :code:`"trappy.event.class:event_column"`
 
 """
+from __future__ import division
+from __future__ import unicode_literals
 
+from builtins import object
+from past.utils import old_div
 from trappy.stats.grammar import Parser
 from trappy.stats import StatConf
 from bart.common.Utils import area_under_curve, interval_sum
@@ -242,7 +246,7 @@ class SignalCompare(object):
             duration = min(a_piv.last_valid_index(), b_piv.last_valid_index())
             duration -= max(a_piv.first_valid_index(),
                             b_piv.first_valid_index())
-            duration = interval_sum(mask[pivot_val], step=step) / duration
+            duration = old_div(interval_sum(mask[pivot_val], step=step), duration)
 
             if self._pivot:
                 result[self._pivot][pivot_val] = area, duration

--- a/bart/sched/SchedAssert.py
+++ b/bart/sched/SchedAssert.py
@@ -126,7 +126,7 @@ class SchedAssert(object):
         :type: function(:mod:`pandas.Series`)
         """
 
-        if aggfunc not in list(self._aggs.keys()):
+        if aggfunc not in self._aggs.keys():
             self._aggs[aggfunc] = MultiTriggerAggregator(self._triggers,
                                                          self._topology,
                                                          aggfunc)

--- a/bart/sched/SchedAssert.py
+++ b/bart/sched/SchedAssert.py
@@ -20,9 +20,9 @@ to aggregate statistics over processor hierarchies.
 """
 from __future__ import division
 from __future__ import unicode_literals
+from __future__ import print_function
 
 from builtins import object
-from past.utils import old_div
 import trappy
 import itertools
 import math
@@ -185,7 +185,7 @@ class SchedAssert(object):
         if percent:
             total = agg.aggregate(level="all", window=window)[0]
             node_value = node_value * 100
-            node_value = old_div(node_value, total)
+            node_value = node_value / total
 
         return node_value
 
@@ -396,7 +396,7 @@ class SchedAssert(object):
                 total_time = self._ftrace.get_duration()
 
             run_time = run_time * 100
-            run_time = old_div(run_time, total_time)
+            run_time = run_time / total_time
 
         return run_time
 

--- a/bart/sched/SchedAssert.py
+++ b/bart/sched/SchedAssert.py
@@ -18,7 +18,11 @@
 The analysis is based on TRAPpy's statistics framework and is potent enough
 to aggregate statistics over processor hierarchies.
 """
+from __future__ import division
+from __future__ import unicode_literals
 
+from builtins import object
+from past.utils import old_div
 import trappy
 import itertools
 import math
@@ -122,7 +126,7 @@ class SchedAssert(object):
         :type: function(:mod:`pandas.Series`)
         """
 
-        if aggfunc not in self._aggs.keys():
+        if aggfunc not in list(self._aggs.keys()):
             self._aggs[aggfunc] = MultiTriggerAggregator(self._triggers,
                                                          self._topology,
                                                          aggfunc)
@@ -181,7 +185,7 @@ class SchedAssert(object):
         if percent:
             total = agg.aggregate(level="all", window=window)[0]
             node_value = node_value * 100
-            node_value = node_value / total
+            node_value = old_div(node_value, total)
 
         return node_value
 
@@ -392,7 +396,7 @@ class SchedAssert(object):
                 total_time = self._ftrace.get_duration()
 
             run_time = run_time * 100
-            run_time = run_time / total_time
+            run_time = old_div(run_time, total_time)
 
         return run_time
 

--- a/bart/sched/SchedMatrix.py
+++ b/bart/sched/SchedMatrix.py
@@ -63,8 +63,12 @@ evaluated execution
     assertSiblings(A3, 2, operator.eq)
     assertSiblings(A4, 2, operator.eq)
 """
+from __future__ import unicode_literals
 
 
+from builtins import str
+from builtins import range
+from builtins import object
 import sys
 import trappy
 import numpy as np

--- a/bart/sched/SchedMatrix.py
+++ b/bart/sched/SchedMatrix.py
@@ -64,7 +64,8 @@ evaluated execution
     assertSiblings(A4, 2, operator.eq)
 """
 from __future__ import unicode_literals
-
+from __future__ import division
+from __future__ import print_function
 
 from builtins import str
 from builtins import range

--- a/bart/sched/SchedMultiAssert.py
+++ b/bart/sched/SchedMultiAssert.py
@@ -16,6 +16,8 @@
 """A library for asserting scheduler scenarios based on the
 statistics aggregation framework"""
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from builtins import object
 import re

--- a/bart/sched/SchedMultiAssert.py
+++ b/bart/sched/SchedMultiAssert.py
@@ -277,7 +277,7 @@ class SchedMultiAssert(object):
         """
 
         events = {}
-        for s_assert in list(self._asserts.values()):
+        for s_assert in self._asserts.values():
             events[s_assert.name] = s_assert.generate_events(level, window=window)
 
         return events
@@ -295,7 +295,7 @@ class SchedMultiAssert(object):
                 xlim = list(window)
 
         events = self.generate_events(level, window)
-        names = [s.name for s in list(self._asserts.values())]
+        names = [s.name for s in self._asserts.values()]
         num_lanes = self._topology.level_span(level)
         lane_prefix = level.upper() + ": "
         return trappy.EventPlot(events, names, xlim,

--- a/bart/sched/SchedMultiAssert.py
+++ b/bart/sched/SchedMultiAssert.py
@@ -15,7 +15,9 @@
 
 """A library for asserting scheduler scenarios based on the
 statistics aggregation framework"""
+from __future__ import unicode_literals
 
+from builtins import object
 import re
 import inspect
 import trappy
@@ -253,7 +255,7 @@ class SchedMultiAssert(object):
         """
         residencies = self.getResidency(level, node, window=window)
 
-        busy_time = sum(v["residency"] for v in residencies.itervalues())
+        busy_time = sum(v["residency"] for v in iter(residencies.values()))
 
         if percent:
             if window:
@@ -273,7 +275,7 @@ class SchedMultiAssert(object):
         """
 
         events = {}
-        for s_assert in self._asserts.values():
+        for s_assert in list(self._asserts.values()):
             events[s_assert.name] = s_assert.generate_events(level, window=window)
 
         return events
@@ -291,7 +293,7 @@ class SchedMultiAssert(object):
                 xlim = list(window)
 
         events = self.generate_events(level, window)
-        names = [s.name for s in self._asserts.values()]
+        names = [s.name for s in list(self._asserts.values())]
         num_lanes = self._topology.level_span(level)
         lane_prefix = level.upper() + ": "
         return trappy.EventPlot(events, names, xlim,

--- a/bart/sched/SchedMultiAssert.py
+++ b/bart/sched/SchedMultiAssert.py
@@ -257,7 +257,7 @@ class SchedMultiAssert(object):
         """
         residencies = self.getResidency(level, node, window=window)
 
-        busy_time = sum(v["residency"] for v in iter(residencies.values()))
+        busy_time = sum(v["residency"] for v in residencies.values())
 
         if percent:
             if window:

--- a/bart/sched/__init__.py
+++ b/bart/sched/__init__.py
@@ -15,7 +15,8 @@
 
 """Initialization for bart.sched"""
 from __future__ import unicode_literals
-
+from __future__ import division
+from __future__ import print_function
 
 from bart.sched import SchedAssert
 from bart.sched import SchedMultiAssert

--- a/bart/sched/__init__.py
+++ b/bart/sched/__init__.py
@@ -14,6 +14,7 @@
 #
 
 """Initialization for bart.sched"""
+from __future__ import unicode_literals
 
 
 from bart.sched import SchedAssert

--- a/bart/sched/functions.py
+++ b/bart/sched/functions.py
@@ -58,8 +58,8 @@ can then be aggregated by specifying a Topology
 """
 from __future__ import division
 from __future__ import unicode_literals
+from __future__ import print_function
 
-from past.utils import old_div
 import numpy as np
 from trappy.stats.Trigger import Trigger
 
@@ -436,7 +436,7 @@ def binary_correlate(series_x, series_y):
     agree = len(series_x[series_x == series_y])
     disagree = len(series_x[series_x != series_y])
 
-    return old_div((agree - disagree), float(len(series_x)))
+    return (agree - disagree) / len(series_x)
 
 def get_pids_for_process(ftrace, execname, cls=None):
     """Get the PIDs for a given process

--- a/bart/sched/functions.py
+++ b/bart/sched/functions.py
@@ -56,7 +56,10 @@ can then be aggregated by specifying a Topology
 
 .. seealso:: :mod:`trappy.stats.Topology.Topology`
 """
+from __future__ import division
+from __future__ import unicode_literals
 
+from past.utils import old_div
 import numpy as np
 from trappy.stats.Trigger import Trigger
 
@@ -180,7 +183,7 @@ def filter_small_gaps(series):
     """
 
     start = None
-    for index, value in series.iteritems():
+    for index, value in series.items():
 
         if value == SCHED_SWITCH_IN:
             if start == None:
@@ -298,7 +301,7 @@ def residency_sum(series, window=None):
             running = select_window(org_series.cumsum(), window)
             if running.values[0] == TASK_RUNNING and running.values[-1] == TASK_RUNNING:
                 return window[1] - window[0]
-        except Exception,e:
+        except Exception as e:
             pass
 
     if len(s_in) != len(s_out):
@@ -433,7 +436,7 @@ def binary_correlate(series_x, series_y):
     agree = len(series_x[series_x == series_y])
     disagree = len(series_x[series_x != series_y])
 
-    return (agree - disagree) / float(len(series_x))
+    return old_div((agree - disagree), float(len(series_x)))
 
 def get_pids_for_process(ftrace, execname, cls=None):
     """Get the PIDs for a given process

--- a/bart/sched/pelt.py
+++ b/bart/sched/pelt.py
@@ -36,7 +36,6 @@ from __future__ import unicode_literals
 
 from builtins import range
 from builtins import object
-from past.utils import old_div
 import math
 
 from collections import namedtuple as namedtuple
@@ -148,8 +147,8 @@ class PeriodicTask(object):
     def __str__(self):
         return "PeriodicTask(start: {:.3f} [ms], period: {:.3f} [ms], run: {:.3f} [ms], "\
                "duty_cycle: {:.3f} [%], pelt_avg: {:d})"\
-            .format(old_div(self.start_us, 1e3), old_div(self.period_us, 1e3),
-                    old_div(self.run_us, 1e3), self.duty_cycle_pct,
+            .format(self.start_us/1e3, self.period_us/1e3,
+                    self.run_us/1e3, self.duty_cycle_pct,
                     self.pelt_avg)
 
 
@@ -254,7 +253,7 @@ class Simulator(object):
         self.half_life_ms = half_life_ms
         self.decay_cap_ms = decay_cap_ms
 
-        self._geom_y = pow(0.5, old_div(1., half_life_ms))
+        self._geom_y = pow(0.5, 1 / half_life_ms)
         self._geom_u = float(self._signal_max) * (1. - self._geom_y)
 
         self.task = None
@@ -318,7 +317,7 @@ class Simulator(object):
             raise ValueError("Wrong time for task parameter")
 
         def _to_pelt_samples(time_us):
-            return old_div(float(time_us), self._sample_us)
+            return time_us / self._sample_us
 
         # Compute max value
         max_pelt = (1. - pow(self._geom_y, _to_pelt_samples(task.run_us)))
@@ -433,8 +432,7 @@ class Simulator(object):
                 pelt_value = self._geomSum(pelt_value, active_us)
 
             # Append PELT sample
-            sample = (_us_to_s(t_us), old_div(t_us,
-                      self._sample_us), running, pelt_value)
+            sample = (_us_to_s(t_us), t_us/self._sample_us, running, pelt_value)
             samples.append(sample)
 
             # Prepare for next sample computation
@@ -542,7 +540,7 @@ class Simulator(object):
 
         :returns: int - Estimated value of PELT signal when the task starts
         """
-        geom_y = pow(0.5, old_div(1., half_life_ms))
+        geom_y = pow(0.5, 1/half_life_ms)
         geom_u = float(cls._signal_max) * (1. - geom_y)
 
         # Compute period of time between when the task started and when the
@@ -554,10 +552,10 @@ class Simulator(object):
                              'happens before the task starts')
         # Compute number of times the simulated PELT would be updated in this
         # period of time
-        updates_since_start = int(old_div(time_since_start, (old_div(cls._sample_us, 1e6))))
+        updates_since_start = int(time_since_start/(cls._sample_us/1e6))
         pelt_val = first_val
         for i in range(updates_since_start):
-            pelt_val = old_div((pelt_val - geom_u), geom_y)
+            pelt_val = (pelt_val - geom_u) / geom_y
 
         return pelt_val
 
@@ -593,8 +591,8 @@ def _s_to_us(time_s, interval_us=1e3, nearest_up=True):
     :type nearest_up: bool
     """
     if nearest_up:
-        return interval_us * int(math.ceil(old_div((1e6 * time_s), interval_us)))
-    return interval_us * int(math.floor(old_div((1e6 * time_s), interval_us)))
+        return interval_us * int(math.ceil((1e6 * time_s)/interval_us))
+    return interval_us * int(math.floor((1e6 * time_s)/interval_us))
 
 
 def _ms_to_us(time_ms, interval_us=1e3, nearest_up=True):
@@ -624,23 +622,23 @@ def _ms_to_us(time_ms, interval_us=1e3, nearest_up=True):
     :type nearest_up: bool
     """
     if nearest_up:
-        return interval_us * int(math.ceil(old_div((1e3 * time_ms), interval_us)))
-    return interval_us * int(math.floor(old_div((1e3 * time_ms), interval_us)))
+        return interval_us * int(math.ceil((1e3 * time_ms)/interval_us))
+    return interval_us * int(math.floor((1e3 * time_ms)/interval_us))
 
 
 def _us_to_s(time_us):
     """Convert [us] into (float) [s]
     """
-    return (old_div(float(time_us), 1e6))
+    return time_us/1e6
 
 
 def _us_to_ms(time_us):
     """Convert [us] into (float) [ms]
     """
-    return (old_div(float(time_us), 1e3))
+    return time_us/1e3
 
 
 def _ms_to_s(time_ms):
     """Convert [ms] into (float) [s]
     """
-    return (old_div(float(time_ms), 1e3))
+    return time_ms/1e3

--- a/bart/sched/pelt.py
+++ b/bart/sched/pelt.py
@@ -31,7 +31,12 @@ Simulator. Both classes have configuration parameters to defined their specific
 behavior. Specifically, the Simulator requires also the PeriodicTask which signal
 has to be computed.
 """
+from __future__ import division
+from __future__ import unicode_literals
 
+from builtins import range
+from builtins import object
+from past.utils import old_div
 import math
 
 from collections import namedtuple as namedtuple
@@ -143,8 +148,8 @@ class PeriodicTask(object):
     def __str__(self):
         return "PeriodicTask(start: {:.3f} [ms], period: {:.3f} [ms], run: {:.3f} [ms], "\
                "duty_cycle: {:.3f} [%], pelt_avg: {:d})"\
-            .format(self.start_us / 1e3, self.period_us / 1e3,
-                    self.run_us / 1e3, self.duty_cycle_pct,
+            .format(old_div(self.start_us, 1e3), old_div(self.period_us, 1e3),
+                    old_div(self.run_us, 1e3), self.duty_cycle_pct,
                     self.pelt_avg)
 
 
@@ -249,7 +254,7 @@ class Simulator(object):
         self.half_life_ms = half_life_ms
         self.decay_cap_ms = decay_cap_ms
 
-        self._geom_y = pow(0.5, 1. / half_life_ms)
+        self._geom_y = pow(0.5, old_div(1., half_life_ms))
         self._geom_u = float(self._signal_max) * (1. - self._geom_y)
 
         self.task = None
@@ -313,7 +318,7 @@ class Simulator(object):
             raise ValueError("Wrong time for task parameter")
 
         def _to_pelt_samples(time_us):
-            return float(time_us) / self._sample_us
+            return old_div(float(time_us), self._sample_us)
 
         # Compute max value
         max_pelt = (1. - pow(self._geom_y, _to_pelt_samples(task.run_us)))
@@ -428,8 +433,8 @@ class Simulator(object):
                 pelt_value = self._geomSum(pelt_value, active_us)
 
             # Append PELT sample
-            sample = (_us_to_s(t_us), t_us /
-                      self._sample_us, running, pelt_value)
+            sample = (_us_to_s(t_us), old_div(t_us,
+                      self._sample_us), running, pelt_value)
             samples.append(sample)
 
             # Prepare for next sample computation
@@ -537,7 +542,7 @@ class Simulator(object):
 
         :returns: int - Estimated value of PELT signal when the task starts
         """
-        geom_y = pow(0.5, 1. / half_life_ms)
+        geom_y = pow(0.5, old_div(1., half_life_ms))
         geom_u = float(cls._signal_max) * (1. - geom_y)
 
         # Compute period of time between when the task started and when the
@@ -549,10 +554,10 @@ class Simulator(object):
                              'happens before the task starts')
         # Compute number of times the simulated PELT would be updated in this
         # period of time
-        updates_since_start = int(time_since_start / (cls._sample_us / 1e6))
+        updates_since_start = int(old_div(time_since_start, (old_div(cls._sample_us, 1e6))))
         pelt_val = first_val
         for i in range(updates_since_start):
-            pelt_val = (pelt_val - geom_u) / geom_y
+            pelt_val = old_div((pelt_val - geom_u), geom_y)
 
         return pelt_val
 
@@ -588,8 +593,8 @@ def _s_to_us(time_s, interval_us=1e3, nearest_up=True):
     :type nearest_up: bool
     """
     if nearest_up:
-        return interval_us * int(math.ceil((1e6 * time_s) / interval_us))
-    return interval_us * int(math.floor((1e6 * time_s) / interval_us))
+        return interval_us * int(math.ceil(old_div((1e6 * time_s), interval_us)))
+    return interval_us * int(math.floor(old_div((1e6 * time_s), interval_us)))
 
 
 def _ms_to_us(time_ms, interval_us=1e3, nearest_up=True):
@@ -619,23 +624,23 @@ def _ms_to_us(time_ms, interval_us=1e3, nearest_up=True):
     :type nearest_up: bool
     """
     if nearest_up:
-        return interval_us * int(math.ceil((1e3 * time_ms) / interval_us))
-    return interval_us * int(math.floor((1e3 * time_ms) / interval_us))
+        return interval_us * int(math.ceil(old_div((1e3 * time_ms), interval_us)))
+    return interval_us * int(math.floor(old_div((1e3 * time_ms), interval_us)))
 
 
 def _us_to_s(time_us):
     """Convert [us] into (float) [s]
     """
-    return (float(time_us) / 1e6)
+    return (old_div(float(time_us), 1e6))
 
 
 def _us_to_ms(time_us):
     """Convert [us] into (float) [ms]
     """
-    return (float(time_us) / 1e3)
+    return (old_div(float(time_us), 1e3))
 
 
 def _ms_to_s(time_ms):
     """Convert [ms] into (float) [s]
     """
-    return (float(time_ms) / 1e3)
+    return (old_div(float(time_ms), 1e3))

--- a/bart/sched/pelt.py
+++ b/bart/sched/pelt.py
@@ -31,8 +31,9 @@ Simulator. Both classes have configuration parameters to defined their specific
 behavior. Specifically, the Simulator requires also the PeriodicTask which signal
 has to be computed.
 """
-from __future__ import division
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from builtins import range
 from builtins import object

--- a/bart/thermal/ThermalAssert.py
+++ b/bart/thermal/ThermalAssert.py
@@ -15,7 +15,11 @@
 """A thermal specific library to assert certain thermal
 behaviours
 """
+from __future__ import division
+from __future__ import unicode_literals
 
+from builtins import object
+from past.utils import old_div
 from bart.common import Utils
 from bart.common.Analyzer import Analyzer
 import numpy as np
@@ -77,8 +81,8 @@ class ThermalAssert(object):
             result[pivot] = sum((index - shift_index)[mask.values])
 
             if percent:
-                result[pivot] = (
-                    result[pivot] * 100.0) / self._ftrace.get_duration()
+                result[pivot] = old_div((
+                    result[pivot] * 100.0), self._ftrace.get_duration())
 
         return result
 

--- a/bart/thermal/ThermalAssert.py
+++ b/bart/thermal/ThermalAssert.py
@@ -19,7 +19,6 @@ from __future__ import division
 from __future__ import unicode_literals
 
 from builtins import object
-from past.utils import old_div
 from bart.common import Utils
 from bart.common.Analyzer import Analyzer
 import numpy as np
@@ -81,8 +80,8 @@ class ThermalAssert(object):
             result[pivot] = sum((index - shift_index)[mask.values])
 
             if percent:
-                result[pivot] = old_div((
-                    result[pivot] * 100.0), self._ftrace.get_duration())
+                result[pivot] = (
+                    (result[pivot] * 100.0)/self._ftrace.get_duration())
 
         return result
 

--- a/bart/thermal/ThermalAssert.py
+++ b/bart/thermal/ThermalAssert.py
@@ -15,8 +15,9 @@
 """A thermal specific library to assert certain thermal
 behaviours
 """
-from __future__ import division
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from builtins import object
 from bart.common import Utils

--- a/bart/thermal/__init__.py
+++ b/bart/thermal/__init__.py
@@ -15,6 +15,7 @@
 
 """Initialization for bart.thermal"""
 from __future__ import unicode_literals
-
+from __future__ import division
+from __future__ import print_function
 
 import bart.thermal.ThermalAssert

--- a/bart/thermal/__init__.py
+++ b/bart/thermal/__init__.py
@@ -14,6 +14,7 @@
 #
 
 """Initialization for bart.thermal"""
+from __future__ import unicode_literals
 
 
 import bart.thermal.ThermalAssert

--- a/bart/version.py
+++ b/bart/version.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2016-2016 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bart/version.py
+++ b/bart/version.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2016-2016 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/docs/api_reference/conf.py
+++ b/docs/api_reference/conf.py
@@ -25,8 +25,10 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
-
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
+
 import sys
 import os
 import shlex

--- a/docs/api_reference/conf.py
+++ b/docs/api_reference/conf.py
@@ -26,6 +26,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from __future__ import unicode_literals
 import sys
 import os
 import shlex

--- a/docs/examples/thermal.py
+++ b/docs/examples/thermal.py
@@ -17,6 +17,9 @@
 An example file for usage of Analyzer for thermal assertions
 """
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
+
 from bart.common.Analyzer import Analyzer
 from trappy.stats.Topology import Topology
 import unittest

--- a/docs/examples/thermal.py
+++ b/docs/examples/thermal.py
@@ -16,6 +16,7 @@
 """
 An example file for usage of Analyzer for thermal assertions
 """
+from __future__ import unicode_literals
 from bart.common.Analyzer import Analyzer
 from trappy.stats.Topology import Topology
 import unittest

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,11 @@
 # limitations under the License.
 #
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
+
 from past.builtins import execfile
 from setuptools import setup, find_packages
-
 
 execfile("bart/version.py")
 

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import unicode_literals
+from past.builtins import execfile
 from setuptools import setup, find_packages
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #    Copyright 2015-2016 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,14 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import print_function
-
-from past.builtins import execfile
 from setuptools import setup, find_packages
 
-execfile("bart/version.py")
+with open("bart/version.py") as f:
+    exec(f.read())
 
 LONG_DESCRIPTION = """Behavioural Analysis involves the expressing the general
 expectation of the state of the system while targeting a single or set of heuristics.
@@ -34,8 +30,10 @@ to assert behaviours using the FTrace output from the kernel
 """
 
 REQUIRES = [
-    "TRAPpy>=3.0",
+    "pandas",
+    "trappy>=3.0",
     "hypothesis>=3.0",
+    "future",
 ]
 
 setup(name='bart-py',
@@ -55,6 +53,7 @@ setup(name='bart-py',
           "License :: OSI Approved :: Apache Software License",
           "Operating System :: POSIX :: Linux",
           "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3",
           # As we depend on trace data from the Linux Kernel/FTrace
           "Topic :: System :: Operating System Kernels :: Linux",
           "Topic :: Scientific/Engineering :: Visualization"

--- a/tests/pelt.py
+++ b/tests/pelt.py
@@ -1,5 +1,7 @@
-from __future__ import division
 from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
+
 from hypothesis import given
 from hypothesis.strategies import integers, tuples, none, one_of
 import unittest

--- a/tests/pelt.py
+++ b/tests/pelt.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from __future__ import unicode_literals
-from past.utils import old_div
 from hypothesis import given
 from hypothesis.strategies import integers, tuples, none, one_of
 import unittest
@@ -76,7 +75,7 @@ class TestSimulator(unittest.TestCase):
         signal = sim.getSignal(task, start_s, end_s)
 
         # Should start no earlier than 1 sample before start_s
-        earliest_start = min(0, start_s - (old_div(sim._sample_us, 1.e6)))
+        earliest_start = min(0, start_s - (im._sample_us/1.e6))
         self.assertGreaterEqual(signal.index[0], earliest_start)
         # Should start no later than start_s
         self.assertLessEqual(signal.index[0], start_s)
@@ -84,7 +83,7 @@ class TestSimulator(unittest.TestCase):
         # Should start no earlier than end_s
         self.assertGreaterEqual(signal.index[-1], end_s)
         # Should end no later than 1 sample after end_s
-        latest_start = end_s + (old_div(sim._sample_us, 1.e6))
+        latest_start = end_s + (sim._sample_us/1.e6)
         self.assertLessEqual(signal.index[-1], latest_start)
 
 if __name__ == "__main__":

--- a/tests/pelt.py
+++ b/tests/pelt.py
@@ -1,7 +1,10 @@
+from __future__ import division
+from __future__ import unicode_literals
+from past.utils import old_div
 from hypothesis import given
 from hypothesis.strategies import integers, tuples, none, one_of
 import unittest
-from sys import maxint
+from sys import maxsize
 
 from bart.sched.pelt import *
 
@@ -22,7 +25,7 @@ periodic_task_args_samples = lambda: tuples(
     nonneg_ints(),  # start_sample
     nonneg_ints(),  # run_samples
     none(),         # duty_cycle_pct
-).filter(lambda (period, _, run, __): run <= period)
+).filter(lambda period___run___: period___run___[2] <= period___run___[0])
 
 # Generate args for PeriodicTask::__init__ args using duty_cycle_pct
 periodic_task_args_pct = lambda: tuples(
@@ -73,7 +76,7 @@ class TestSimulator(unittest.TestCase):
         signal = sim.getSignal(task, start_s, end_s)
 
         # Should start no earlier than 1 sample before start_s
-        earliest_start = min(0, start_s - (sim._sample_us / 1.e6))
+        earliest_start = min(0, start_s - (old_div(sim._sample_us, 1.e6)))
         self.assertGreaterEqual(signal.index[0], earliest_start)
         # Should start no later than start_s
         self.assertLessEqual(signal.index[0], start_s)
@@ -81,7 +84,7 @@ class TestSimulator(unittest.TestCase):
         # Should start no earlier than end_s
         self.assertGreaterEqual(signal.index[-1], end_s)
         # Should end no later than 1 sample after end_s
-        latest_start = end_s + (sim._sample_us / 1.e6)
+        latest_start = end_s + (old_div(sim._sample_us, 1.e6))
         self.assertLessEqual(signal.index[-1], latest_start)
 
 if __name__ == "__main__":

--- a/tests/test_common_utils.py
+++ b/tests/test_common_utils.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2016 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_common_utils.py
+++ b/tests/test_common_utils.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2016 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +12,9 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from bart.common import Utils
 from bart.common.Analyzer import Analyzer

--- a/tests/test_pelt_sim.py
+++ b/tests/test_pelt_sim.py
@@ -1,3 +1,5 @@
+from __future__ import division
+from __future__ import unicode_literals
 #    Copyright 2015-2016 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,10 +15,11 @@
 # limitations under the License.
 #
 
+from past.utils import old_div
 from bart.sched.pelt import *
 from hypothesis import given
 from hypothesis.strategies import integers, tuples, none, one_of
-from sys import maxint
+from sys import maxsize
 from utils_tests import TestBART
 
 # Required to use `int` not `long` henx ma=maxint
@@ -36,7 +39,7 @@ periodic_task_args_samples = lambda: tuples(
     nonneg_ints(),  # start_sample
     nonneg_ints(),  # run_samples
     none(),         # duty_cycle_pct
-).filter(lambda (period, _, run, __): run <= period)
+).filter(lambda period___run___: period___run___[2] <= period___run___[0])
 
 # Generate args for PeriodicTask::__init__ args using duty_cycle_pct
 periodic_task_args_pct = lambda: tuples(
@@ -92,7 +95,7 @@ class TestSimulator(TestBART):
         signal = sim.getSignal(task, start_s, end_s)
 
         # Should start no earlier than 1 sample before start_s
-        earliest_start = min(0, start_s - (sim._sample_us / 1.e6))
+        earliest_start = min(0, start_s - (old_div(sim._sample_us, 1.e6)))
         self.assertGreaterEqual(signal.index[0], earliest_start)
         # Should start no later than start_s
         self.assertLessEqual(signal.index[0], start_s)
@@ -100,7 +103,7 @@ class TestSimulator(TestBART):
         # Should start no earlier than end_s
         self.assertGreaterEqual(signal.index[-1], end_s)
         # Should end no later than 1 sample after end_s
-        latest_start = end_s + (sim._sample_us / 1.e6)
+        latest_start = end_s + (old_div(sim._sample_us, 1.e6))
         self.assertLessEqual(signal.index[-1], latest_start)
 
     @given(periodic_task_args(), simulator_args())
@@ -113,7 +116,7 @@ class TestSimulator(TestBART):
         signal = sim.getSignal(task)
         stats = sim.getStats()
 
-        expected_mean = (task.duty_cycle_pct * 1024) / 100
+        expected_mean = old_div((task.duty_cycle_pct * 1024), 100)
 
         self.assertEqual(stats.pelt_avg, expected_mean)
 

--- a/tests/test_pelt_sim.py
+++ b/tests/test_pelt_sim.py
@@ -1,5 +1,3 @@
-from __future__ import division
-from __future__ import unicode_literals
 #    Copyright 2015-2016 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +12,9 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from bart.sched.pelt import *
 from hypothesis import given

--- a/tests/test_pelt_sim.py
+++ b/tests/test_pelt_sim.py
@@ -19,10 +19,12 @@ from __future__ import print_function
 from bart.sched.pelt import *
 from hypothesis import given
 from hypothesis.strategies import integers, tuples, none, one_of
-from sys import maxsize
 from utils_tests import TestBART
+import sys
+import math
 
-# Required to use `int` not `long` henx ma=maxint
+# Required to use `int` not `long` on Python 2 ,hence ma=maxint
+maxint = getattr(sys, 'maxint', sys.maxsize)
 nonneg_ints = lambda mi=0, ma=maxint: integers(min_value=mi, max_value=ma)
 
 # Generate a Simulator

--- a/tests/test_pelt_sim.py
+++ b/tests/test_pelt_sim.py
@@ -15,7 +15,6 @@ from __future__ import unicode_literals
 # limitations under the License.
 #
 
-from past.utils import old_div
 from bart.sched.pelt import *
 from hypothesis import given
 from hypothesis.strategies import integers, tuples, none, one_of
@@ -95,7 +94,7 @@ class TestSimulator(TestBART):
         signal = sim.getSignal(task, start_s, end_s)
 
         # Should start no earlier than 1 sample before start_s
-        earliest_start = min(0, start_s - (old_div(sim._sample_us, 1.e6)))
+        earliest_start = min(0, start_s - (sim._sample_us/1.e6))
         self.assertGreaterEqual(signal.index[0], earliest_start)
         # Should start no later than start_s
         self.assertLessEqual(signal.index[0], start_s)
@@ -103,7 +102,7 @@ class TestSimulator(TestBART):
         # Should start no earlier than end_s
         self.assertGreaterEqual(signal.index[-1], end_s)
         # Should end no later than 1 sample after end_s
-        latest_start = end_s + (old_div(sim._sample_us, 1.e6))
+        latest_start = end_s + (sim._sample_us/1.e6)
         self.assertLessEqual(signal.index[-1], latest_start)
 
     @given(periodic_task_args(), simulator_args())
@@ -116,7 +115,7 @@ class TestSimulator(TestBART):
         signal = sim.getSignal(task)
         stats = sim.getStats()
 
-        expected_mean = old_div((task.duty_cycle_pct * 1024), 100)
+        expected_mean = (task.duty_cycle_pct * 1024)/100
 
-        self.assertEqual(stats.pelt_avg, expected_mean)
+        self.assertEqual(math.floor(stats.pelt_avg), math.floor(expected_mean))
 

--- a/tests/test_sched_assert.py
+++ b/tests/test_sched_assert.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2016 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,9 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 from bart.sched.SchedAssert import SchedAssert
 from bart.sched.SchedMultiAssert import SchedMultiAssert

--- a/tests/test_sched_assert.py
+++ b/tests/test_sched_assert.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2016 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_sched_functions.py
+++ b/tests/test_sched_functions.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2016-2016 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +12,9 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 import trappy
 

--- a/tests/test_sched_functions.py
+++ b/tests/test_sched_functions.py
@@ -46,7 +46,6 @@ class TestSchedFunctions(utils_tests.SetupDirectory):
         from bart.sched.functions import get_pids_for_process
 
         trace_file = "trace.txt"
-        raw_trace_file = "trace.raw.txt"
         in_data = """          <idle>-0     [001] 10826.894644: sched_switch:          prev_comm=swapper/1 prev_pid=0 prev_prio=120 prev_state=0 next_comm=rt-app next_pid=3268 next_prio=120
             wmig-3268  [001] 10826.894778: sched_switch:          prev_comm=wmig prev_pid=3268 prev_prio=120 prev_state=1 next_comm=rt-app next_pid=3269 next_prio=120
            wmig1-3269  [001] 10826.905152: sched_switch:          prev_comm=wmig1 prev_pid=3269 prev_prio=120 prev_state=1 next_comm=wmig next_pid=3268 next_prio=120
@@ -57,16 +56,8 @@ class TestSchedFunctions(utils_tests.SetupDirectory):
            wmig1-3269  [005] 10827.031061: sched_switch:          prev_comm=wmig1 prev_pid=3269 prev_prio=120 prev_state=0 next_comm=wmig next_pid=3268 next_prio=120
             wmig-3268  [005] 10827.050645: sched_switch:          prev_comm=wmig prev_pid=3268 prev_prio=120 prev_state=1 next_comm=swapper/5 next_pid=0 next_prio=120
 """
-
-        # We create an empty trace.txt to please trappy ...
         with open(trace_file, "w") as fout:
-            fout.write("")
-
-        # ... but we only put the sched_switch events in the raw trace
-        # file because that's where trappy is going to look for
-        with open(raw_trace_file, "w") as fout:
             fout.write(in_data)
 
         trace = trappy.FTrace(trace_file)
-
         self.assertEquals(get_pids_for_process(trace, "wmig"), [3268])

--- a/tests/test_sched_functions.py
+++ b/tests/test_sched_functions.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2016-2016 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -1,5 +1,3 @@
-from __future__ import division
-from __future__ import unicode_literals
 #    Copyright 2015-2016 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +12,9 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 import pandas as pd
 import trappy

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -1,3 +1,5 @@
+from __future__ import division
+from __future__ import unicode_literals
 #    Copyright 2015-2016 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +15,7 @@
 # limitations under the License.
 #
 
+from past.utils import old_div
 import pandas as pd
 import trappy
 from utils_tests import TestBART
@@ -40,7 +43,7 @@ class TestSignalCompare(TestBART):
         trace.add_parsed_event("event", df)
 
         s = SignalCompare(trace, "event:A", "event:B")
-        expected = (1.5, 2.0 / 7)
+        expected = (1.5, old_div(2.0, 7))
         self.assertEqual(
             s.conditional_compare(
                 "event:A > event:B",
@@ -58,7 +61,7 @@ class TestSignalCompare(TestBART):
         trace.add_parsed_event("event", df)
 
         s = SignalCompare(trace, "event:A", "event:B")
-        expected = (1.5, 2.0 / 7)
+        expected = (1.5, old_div(2.0, 7))
         self.assertEqual(
             s.get_overshoot(method="rect"),
             expected)
@@ -86,7 +89,7 @@ class TestSignalCompare(TestBART):
         trace.add_parsed_event("event", df)
 
         s = SignalCompare(trace, "event:A", "event:B")
-        expected = (4.0 / 14.0, 1.0)
+        expected = (old_div(4.0, 14.0), 1.0)
         self.assertEqual(
             s.get_undershoot(method="rect"),
             expected)

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -15,7 +15,6 @@ from __future__ import unicode_literals
 # limitations under the License.
 #
 
-from past.utils import old_div
 import pandas as pd
 import trappy
 from utils_tests import TestBART
@@ -43,7 +42,7 @@ class TestSignalCompare(TestBART):
         trace.add_parsed_event("event", df)
 
         s = SignalCompare(trace, "event:A", "event:B")
-        expected = (1.5, old_div(2.0, 7))
+        expected = (1.5, 2.0/7)
         self.assertEqual(
             s.conditional_compare(
                 "event:A > event:B",
@@ -61,7 +60,7 @@ class TestSignalCompare(TestBART):
         trace.add_parsed_event("event", df)
 
         s = SignalCompare(trace, "event:A", "event:B")
-        expected = (1.5, old_div(2.0, 7))
+        expected = (1.5, 2.0/7)
         self.assertEqual(
             s.get_overshoot(method="rect"),
             expected)
@@ -89,7 +88,7 @@ class TestSignalCompare(TestBART):
         trace.add_parsed_event("event", df)
 
         s = SignalCompare(trace, "event:A", "event:B")
-        expected = (old_div(4.0, 14.0), 1.0)
+        expected = (4.0/14.0, 1.0)
         self.assertEqual(
             s.get_undershoot(method="rect"),
             expected)

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 #    Copyright 2015-2016 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 #    Copyright 2015-2016 ARM Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,9 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import print_function
 
 import unittest
 import os


### PR DESCRIPTION
Add Python 3 support using the past package, and its 2to3-based futurize script: https://pypi.org/project/past/

TODO: update the required version of TRAPpy once its Python 3 PR is merged

TypeError in TRAPpy are fixed by its Python 3 PR and will go away once merged