### PR TITLE
sched: functions: Convert to python3 syntax

### DIFF
--- a/bart/sched/functions.py
+++ b/bart/sched/functions.py
@@ -298,7 +298,7 @@ def residency_sum(series, window=None):
             running = select_window(org_series.cumsum(), window)
             if running.values[0] == TASK_RUNNING and running.values[-1] == TASK_RUNNING:
                 return window[1] - window[0]
-        except Exception,e:
+        except Exception as e:
             pass
 
     if len(s_in) != len(s_out):


### PR DESCRIPTION
From python 3.x, 'as' is required to assign an exception to a variable.
The same is also supported in python 2.6+, so let's switch to this
syntax to make this work with python 3.

Signed-off-by: Georgi Djakov <georgi.djakov@linaro.org>